### PR TITLE
Add Cloudwatch logs to Elasticsearch module

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,6 @@ Module to ship AWS Cloudwatch logs to AWS Elasticsearch. This assumes that your 
 ```
 module "cwlogs-to-es" {
   source               = "github.com/skyscrapers/terraform-logging/cwlogs-to-es"
-  #elasticsearch_sg_id = "${module.logs.sg_id}"
   elasticsearch_sg_id  ="sg-224234c"
   elasticsearch_dns    = "${module.logs.endpoint}"
   environment          = "${terraform.workspace}"

--- a/README.md
+++ b/README.md
@@ -49,3 +49,30 @@ module "cloudtrail-s3" {
 EOF
 }
 ```
+
+## cwlogs-to-es
+Module to ship AWS Cloudwatch logs to AWS Elasticsearch. This assumes that your AWS Elasticsearch is running inside a VPC and your Lambda will be deployed inside that VPC. The needed IAM rights + securitygroups and rules are created. To make this work, you need to choose a subnet that has access to the AWS elasticsearch service.
+
+### Variables
+
+* [`elasticsearch_sg_id`]: String(required): Security group ID of the AWS elasticsearch service.
+* [`elasticsearch_dns`]: String(required): Elasticsearch DNS hostname
+* [`environment`]: String(required): the name of the environment these subnets belong to (prod,stag,dev)
+* [`subnet_ids`]: List(required): Subnet IDs you want to deploy the lambda in
+* [`log_group_name`]: String(required): Cloudwatch logs loggroup name to use
+* [`aws_account_id`]: String(optional): Your AWS account ID. Default to your current AWS account
+* [`aws_region`]: String(optional): AWS region where you have your AWS cloudwtach loggroup deployed in. Defaults to your current region
+
+### Example
+
+```
+module "cwlogs-to-es" {
+  source               = "github.com/skyscrapers/terraform-logging/cwlogs-to-es"
+  #elasticsearch_sg_id = "${module.logs.sg_id}"
+  elasticsearch_sg_id  ="sg-224234c"
+  elasticsearch_dns    = "${module.logs.endpoint}"
+  environment          = "${terraform.workspace}"
+  subnet_ids           = "${data.terraform_remote_state.static.private_db_subnets}"
+  log_group_name       = "kubernetes"
+}
+```

--- a/cwlogs-to-es/cw.tf
+++ b/cwlogs-to-es/cw.tf
@@ -1,0 +1,6 @@
+resource "aws_cloudwatch_log_subscription_filter" "cwlogs-es" {
+  name            = "lambda_cwlogs_to_elasticsearch_${var.environment}"
+  log_group_name  = "${var.log_group_name}"
+  filter_pattern  = ""
+  destination_arn = "${aws_lambda_function.lambda.arn}"
+}

--- a/cwlogs-to-es/iam.tf
+++ b/cwlogs-to-es/iam.tf
@@ -1,0 +1,54 @@
+data "aws_iam_policy_document" "policy" {
+  statement {
+    sid    = ""
+    effect = "Allow"
+
+    principals {
+      identifiers = ["lambda.amazonaws.com"]
+      type        = "Service"
+    }
+
+    actions = ["sts:AssumeRole"]
+  }
+}
+
+resource "aws_iam_role" "iam_for_lambda" {
+  name               = "lambda_cwlogs_to_elasticsearch_${var.environment}"
+  assume_role_policy = "${data.aws_iam_policy_document.policy.json}"
+}
+
+resource "aws_iam_role_policy_attachment" "vpc-execution" {
+    role       = "${aws_iam_role.iam_for_lambda.name}"
+    policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole"
+}
+
+resource "aws_iam_role_policy" "cwlogs-es" {
+  name = "lambda_cwlogs_to_elasticsearch_${var.environment}"
+  role = "${aws_iam_role.iam_for_lambda.id}"
+
+  policy = "${data.aws_iam_policy_document.cwlogs-es.json}"
+}
+
+data "aws_iam_policy_document" "cwlogs-es" {
+  statement {
+    actions = [
+      "logs:CreateLogGroup",
+      "logs:CreateLogStream",
+      "logs:PutLogEvents"
+    ]
+
+    resources = [
+      "arn:aws:logs:*:*:*",
+    ]
+  }
+
+  statement {
+    actions = [
+      "es:ESHttpPost",
+    ]
+
+    resources = [
+      "arn:aws:es:*:*:*",
+    ]
+  }
+}

--- a/cwlogs-to-es/lambda.tf
+++ b/cwlogs-to-es/lambda.tf
@@ -1,0 +1,51 @@
+data "template_file" "node" {
+  template = "${file("${path.module}/lambda/index.js")}"
+
+  vars {
+    elasticsearch_dns = "${var.elasticsearch_dns}"
+  }
+}
+
+data "archive_file" "zip" {
+  type        = "zip"
+  source_content = "${data.template_file.node.rendered}"
+  source_content_filename = "index.js"
+  output_path = "cw_logs_es.zip"
+}
+
+resource "aws_lambda_function" "lambda" {
+  function_name = "lambda_cwlogs_to_elasticsearch_${var.environment}"
+  description   = "Lambda function to ship AWS Cloudwatch logs to Elasticsearch for ${var.environment}"
+
+  filename         = "${data.archive_file.zip.output_path}"
+  source_code_hash = "${data.archive_file.zip.output_sha}"
+
+  role    = "${aws_iam_role.iam_for_lambda.arn}"
+  handler = "index.handler"
+  runtime = "nodejs4.3"
+  timeout = "60"
+
+  vpc_config {
+      subnet_ids = ["${var.subnet_ids}"]
+      security_group_ids = ["${aws_security_group.lambda.id}"]
+  }
+}
+
+data "aws_region" "current" {
+  current = true
+}
+
+data "aws_caller_identity" "current" {}
+
+locals {
+    aws_region = "${var.aws_region != "" ? var.aws_region : data.aws_region.current.name}"
+    aws_account_id = "${var.aws_account_id != "" ? var.aws_account_id : data.aws_caller_identity.current.account_id}"
+}
+
+resource "aws_lambda_permission" "allow_cloudwatch" {
+  statement_id   = "AllowExecutionFromCloudWatch${var.environment}"
+  action         = "lambda:InvokeFunction"
+  function_name  = "${aws_lambda_function.lambda.function_name}"
+  principal      = "logs.amazonaws.com"
+  source_arn     = "arn:aws:logs:${local.aws_region}:${local.aws_account_id}:log-group:${var.log_group_name}:*"
+}

--- a/cwlogs-to-es/lambda/index.js
+++ b/cwlogs-to-es/lambda/index.js
@@ -1,0 +1,245 @@
+// v1.1.2
+var https = require('https');
+var zlib = require('zlib');
+var crypto = require('crypto');
+
+var endpoint = '${elasticsearch_dns}';
+
+exports.handler = function(input, context) {
+    // decode input from base64
+    var zippedInput = new Buffer(input.awslogs.data, 'base64');
+
+    // decompress the input
+    zlib.gunzip(zippedInput, function(error, buffer) {
+        if (error) { context.fail(error); return; }
+
+        // parse the input from JSON
+        var awslogsData = JSON.parse(buffer.toString('utf8'));
+
+        // transform the input to Elasticsearch documents
+        var elasticsearchBulkData = transform(awslogsData);
+
+        // skip control messages
+        if (!elasticsearchBulkData) {
+            console.log('Received a control message');
+            context.succeed('Control message handled successfully');
+            return;
+        }
+
+        // post documents to the Amazon Elasticsearch Service
+        post(elasticsearchBulkData, function(error, success, statusCode, failedItems) {
+            console.log('Response: ' + JSON.stringify({
+                "statusCode": statusCode
+            }));
+
+            if (error) {
+                console.log('Error: ' + JSON.stringify(error, null, 2));
+
+                if (failedItems && failedItems.length > 0) {
+                    console.log("Failed Items: " +
+                        JSON.stringify(failedItems, null, 2));
+                }
+
+                context.fail(JSON.stringify(error));
+            } else {
+                console.log('Success: ' + JSON.stringify(success));
+                context.succeed('Success');
+            }
+        });
+    });
+};
+
+function transform(payload) {
+    if (payload.messageType === 'CONTROL_MESSAGE') {
+        return null;
+    }
+
+    var bulkRequestBody = '';
+
+    payload.logEvents.forEach(function(logEvent) {
+        var timestamp = new Date(1 * logEvent.timestamp);
+
+        // index name format: cwl-YYYY.MM.DD
+        var indexName = [
+            'cwl-' + timestamp.getUTCFullYear(), // year
+            ('0' + (timestamp.getUTCMonth() + 1)).slice(-2), // month
+            ('0' + timestamp.getUTCDate()).slice(-2) // day
+        ].join('.');
+
+        var source = buildSource(logEvent.message, logEvent.extractedFields);
+        source['@id'] = logEvent.id;
+        source['@timestamp'] = new Date(1 * logEvent.timestamp).toISOString();
+        source['@message'] = logEvent.message;
+        source['@owner'] = payload.owner;
+        source['@log_group'] = payload.logGroup;
+        source['@log_stream'] = payload.logStream;
+
+        var action = { "index": {} };
+        action.index._index = indexName;
+        action.index._type = payload.logGroup;
+        action.index._id = logEvent.id;
+
+        bulkRequestBody += [
+            JSON.stringify(action),
+            JSON.stringify(source),
+        ].join('\n') + '\n';
+    });
+    return bulkRequestBody;
+}
+
+function buildSource(message, extractedFields) {
+    if (extractedFields) {
+        var source = {};
+
+        for (var key in extractedFields) {
+            if (extractedFields.hasOwnProperty(key) && extractedFields[key]) {
+                var value = extractedFields[key];
+
+                if (isNumeric(value)) {
+                    source[key] = 1 * value;
+                    continue;
+                }
+
+                jsonSubString = extractJson(value);
+                if (jsonSubString !== null) {
+                    source['$' + key] = JSON.parse(jsonSubString);
+                }
+
+                source[key] = value;
+            }
+        }
+        return source;
+    }
+
+    jsonSubString = extractJson(message);
+    if (jsonSubString !== null) {
+        return JSON.parse(jsonSubString);
+    }
+
+    return {};
+}
+
+function extractJson(message) {
+    var jsonStart = message.indexOf('{');
+    if (jsonStart < 0) return null;
+    var jsonSubString = message.substring(jsonStart);
+    return isValidJson(jsonSubString) ? jsonSubString : null;
+}
+
+function isValidJson(message) {
+    try {
+        JSON.parse(message);
+    } catch (e) { return false; }
+    return true;
+}
+
+function isNumeric(n) {
+    return !isNaN(parseFloat(n)) && isFinite(n);
+}
+
+function post(body, callback) {
+    var requestParams = buildRequest(endpoint, body);
+
+    var request = https.request(requestParams, function(response) {
+        var responseBody = '';
+        response.on('data', function(chunk) {
+            responseBody += chunk;
+        });
+        response.on('end', function() {
+            var info = JSON.parse(responseBody);
+            var failedItems;
+            var success;
+
+            if (response.statusCode >= 200 && response.statusCode < 299) {
+                failedItems = info.items.filter(function(x) {
+                    return x.index.status >= 300;
+                });
+
+                success = {
+                    "attemptedItems": info.items.length,
+                    "successfulItems": info.items.length - failedItems.length,
+                    "failedItems": failedItems.length
+                };
+            }
+
+            var error = response.statusCode !== 200 || info.errors === true ? {
+                "statusCode": response.statusCode,
+                "responseBody": responseBody
+            } : null;
+
+            callback(error, success, response.statusCode, failedItems);
+        });
+    }).on('error', function(e) {
+        callback(e);
+    });
+    request.end(requestParams.body);
+}
+
+function buildRequest(endpoint, body) {
+    var endpointParts = endpoint.match(/^([^\.]+)\.?([^\.]*)\.?([^\.]*)\.amazonaws\.com$/);
+    var region = endpointParts[2];
+    var service = endpointParts[3];
+    var datetime = (new Date()).toISOString().replace(/[:\-]|\.\d{3}/g, '');
+    var date = datetime.substr(0, 8);
+    var kDate = hmac('AWS4' + process.env.AWS_SECRET_ACCESS_KEY, date);
+    var kRegion = hmac(kDate, region);
+    var kService = hmac(kRegion, service);
+    var kSigning = hmac(kService, 'aws4_request');
+
+    var request = {
+        host: endpoint,
+        method: 'POST',
+        path: '/_bulk',
+        body: body,
+        headers: {
+            'Content-Type': 'application/json',
+            'Host': endpoint,
+            'Content-Length': Buffer.byteLength(body),
+            'X-Amz-Security-Token': process.env.AWS_SESSION_TOKEN,
+            'X-Amz-Date': datetime
+        }
+    };
+
+    var canonicalHeaders = Object.keys(request.headers)
+        .sort(function(a, b) { return a.toLowerCase() < b.toLowerCase() ? -1 : 1; })
+        .map(function(k) { return k.toLowerCase() + ':' + request.headers[k]; })
+        .join('\n');
+
+    var signedHeaders = Object.keys(request.headers)
+        .map(function(k) { return k.toLowerCase(); })
+        .sort()
+        .join(';');
+
+    var canonicalString = [
+        request.method,
+        request.path, '',
+        canonicalHeaders, '',
+        signedHeaders,
+        hash(request.body, 'hex'),
+    ].join('\n');
+
+    var credentialString = [date, region, service, 'aws4_request'].join('/');
+
+    var stringToSign = [
+        'AWS4-HMAC-SHA256',
+        datetime,
+        credentialString,
+        hash(canonicalString, 'hex')
+    ].join('\n');
+
+    request.headers.Authorization = [
+        'AWS4-HMAC-SHA256 Credential=' + process.env.AWS_ACCESS_KEY_ID + '/' + credentialString,
+        'SignedHeaders=' + signedHeaders,
+        'Signature=' + hmac(kSigning, stringToSign, 'hex')
+    ].join(', ');
+
+    return request;
+}
+
+function hmac(key, str, encoding) {
+    return crypto.createHmac('sha256', key).update(str, 'utf8').digest(encoding);
+}
+
+function hash(str, encoding) {
+    return crypto.createHash('sha256').update(str, 'utf8').digest(encoding);
+}

--- a/cwlogs-to-es/sg.tf
+++ b/cwlogs-to-es/sg.tf
@@ -1,0 +1,34 @@
+data "aws_subnet" "selected" {
+  id = "${var.subnet_ids[0]}"
+}
+
+resource "aws_security_group" "lambda" {
+  name        = "lambda_cwlogs_to_elasticsearch_${var.environment}"
+  description = "Lambda sg for cwlogs to elasticsearch"
+  vpc_id      = "${data.aws_subnet.selected.vpc_id}"
+
+  tags {
+    Name = "lambda_cwlogs_to_elasticsearch_${var.environment}"
+    Environment = "${var.environment}"
+  }
+}
+
+resource "aws_security_group_rule" "lambda_to_es" {
+  type            = "egress"
+  from_port       = 443
+  to_port         = 443
+  protocol        = "tcp"
+  source_security_group_id = "${var.elasticsearch_sg_id}"
+
+  security_group_id = "${aws_security_group.lambda.id}" 
+}
+
+resource "aws_security_group_rule" "es_from_lambda" {
+  type            = "ingress"
+  from_port       = 443
+  to_port         = 443
+  protocol        = "tcp"
+  source_security_group_id = "${aws_security_group.lambda.id}" 
+  
+  security_group_id = "${var.elasticsearch_sg_id}"
+}

--- a/cwlogs-to-es/variables.tf
+++ b/cwlogs-to-es/variables.tf
@@ -1,0 +1,30 @@
+variable "elasticsearch_sg_id" {
+    description = "Security group ID of the AWS elasticsearch service"
+}
+
+variable "elasticsearch_dns" {
+    description = "Elasticsearch DNS hostname"
+}
+
+variable "environment" {
+    description = "The name of the environment these subnets belong to (prod,stag,dev)"
+}
+
+variable "subnet_ids" {
+    description = "Subnet IDs you want to deploy the lambda in"
+    type = "list"
+}
+
+variable "log_group_name" {
+    description = "Cloudwatch logs loggroup name to use"
+}
+
+variable "aws_account_id" {
+    description = "Your AWS account ID. Default to your current AWS account"
+    default = ""
+}
+
+variable "aws_region" {
+    description = "AWS region where you have your AWS cloudwtach loggroup deployed in. Defaults to your current region"
+    default = ""
+}


### PR DESCRIPTION
This adds a TF module to create the linking between an already existing Cloudwatch loggroup and AWS Elasticsearch. When this is setup properly, this will ship all the logs from Cloudwatch logs to Elasticsearch