### PR TITLE
cloudwatch logs in JSON

### DIFF
--- a/cwlogs-to-es/lambda.tf
+++ b/cwlogs-to-es/lambda.tf
@@ -22,7 +22,7 @@ resource "aws_lambda_function" "lambda" {
 
   role    = "${aws_iam_role.iam_for_lambda.arn}"
   handler = "index.handler"
-  runtime = "nodejs4.3"
+  runtime = "nodejs8.10"
   timeout = "60"
 
   vpc_config {

--- a/cwlogs-to-es/lambda/index.js
+++ b/cwlogs-to-es/lambda/index.js
@@ -67,6 +67,13 @@ function transform(payload) {
         ].join('.');
 
         var source = buildSource(logEvent.message, logEvent.extractedFields);
+        source["log_json"]={}
+        if(source["log"]){
+            var jsonSubString = extractJson(source["log"]);
+            if (jsonSubString !== null) {
+                source["log_json"]= JSON.parse(jsonSubString);
+            }
+        }
         source['@id'] = logEvent.id;
         source['@timestamp'] = new Date(1 * logEvent.timestamp).toISOString();
         source['@message'] = logEvent.message;


### PR DESCRIPTION
adding option to detect logs in json and send them in the correct format to Kibana

This might not be the best approach so please let me know if you have better ideas.
It has been tested on a customer already.

The main reason why I don't add the to the `log` field the json formatted content is because there might be some content mismatch in ES