### PR TITLE
adding option to specify index-prefix for cwlogs-to-es

### DIFF
--- a/cwlogs-to-es/lambda.tf
+++ b/cwlogs-to-es/lambda.tf
@@ -3,6 +3,7 @@ data "template_file" "node" {
 
   vars {
     elasticsearch_dns = "${var.elasticsearch_dns}"
+    index_prefix      = "${var.index_prefix}"
   }
 }
 

--- a/cwlogs-to-es/lambda/index.js
+++ b/cwlogs-to-es/lambda/index.js
@@ -4,6 +4,7 @@ var zlib = require('zlib');
 var crypto = require('crypto');
 
 var endpoint = '${elasticsearch_dns}';
+var index_prefix = '${index_prefix}'
 
 exports.handler = function(input, context) {
     // decode input from base64
@@ -61,7 +62,7 @@ function transform(payload) {
 
         // index name format: cwl-YYYY.MM.DD
         var indexName = [
-            'cwl-' + timestamp.getUTCFullYear(), // year
+            index_prefix + '-' + timestamp.getUTCFullYear(), // year
             ('0' + (timestamp.getUTCMonth() + 1)).slice(-2), // month
             ('0' + timestamp.getUTCDate()).slice(-2) // day
         ].join('.');

--- a/cwlogs-to-es/variables.tf
+++ b/cwlogs-to-es/variables.tf
@@ -28,3 +28,7 @@ variable "aws_region" {
   description = "AWS region where you have your AWS cloudwtach loggroup deployed in. Defaults to your current region"
   default     = ""
 }
+
+variable "index_prefix" {
+  default = "cwl"
+}


### PR DESCRIPTION
This allows the option to specify a different `index_prefix`.
This can be useful if you have 2 different log-groups with different content type sent to the same ES server.