### PR TITLE
feature: lambda logs are only kept for 30 days (default)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,19 +1,22 @@
 # terraform-logging
+
 Terraform module to setup logging in AWS
 
-##cloudtrail
+## cloudtrail
 
 This modules allows to setup cloudtrail passing an existing s3 bucket
+
 ### Variables
 
 See the [cloudtrail/variables.tf](cloudtrail/variables.tf) file.
 
 ### Outputs
+
 /
 
 ### Example
 
-```
+```hcl
 module "cloudtrail" {
   source                   = "github.com/skyscrapers/terraform-logging/cloudtrail"
   bucket_name              = "test-cloudtrail-log"
@@ -24,6 +27,7 @@ module "cloudtrail" {
 ```
 
 ## cloudtrail-s3
+
 Terraform module to setup the cloudtrail s3 bucket and enable cloudtrail
 
 ### Variables
@@ -31,11 +35,12 @@ Terraform module to setup the cloudtrail s3 bucket and enable cloudtrail
 See the [cloudtrail-s3/variables.tf](cloudtrail-s3/variables.tf) file.
 
 ### Outputs
+
 /
 
 ### Example
 
-```
+```hcl
 module "cloudtrail-s3" {
   source                   = "github.com/skyscrapers/terraform-logging/cloudtrail-s3"
   bucket_name              = "test-cloudtrail-log"
@@ -51,6 +56,7 @@ EOF
 ```
 
 ## cwlogs-to-es
+
 Module to ship AWS Cloudwatch logs to AWS Elasticsearch. This assumes that your AWS Elasticsearch is running inside a VPC and your Lambda will be deployed inside that VPC. The needed IAM rights + securitygroups and rules are created. To make this work, you need to choose a subnet that has access to the AWS elasticsearch service.
 
 ### Variables
@@ -62,10 +68,11 @@ Module to ship AWS Cloudwatch logs to AWS Elasticsearch. This assumes that your 
 * [`log_group_name`]: String(required): Cloudwatch logs loggroup name to use
 * [`aws_account_id`]: String(optional): Your AWS account ID. Default to your current AWS account
 * [`aws_region`]: String(optional): AWS region where you have your AWS cloudwtach loggroup deployed in. Defaults to your current region
+* [`retention_in_days`]: Int(optional): How many days the lambda logs are kept. Defaults to 30 days
 
 ### Example
 
-```
+```hcl
 module "cwlogs-to-es" {
   source               = "github.com/skyscrapers/terraform-logging/cwlogs-to-es"
   elasticsearch_sg_id  ="sg-224234c"

--- a/cwlogs-to-es/cw.tf
+++ b/cwlogs-to-es/cw.tf
@@ -4,3 +4,9 @@ resource "aws_cloudwatch_log_subscription_filter" "cwlogs-es" {
   filter_pattern  = ""
   destination_arn = "${aws_lambda_function.lambda.arn}"
 }
+
+resource "aws_cloudwatch_log_group" "lambda" {
+  name = "/aws/lambda/lambda_cwlogs_to_elasticsearch_${var.environment}"
+
+  retention_in_days = "${var.retention_in_days}"
+}

--- a/cwlogs-to-es/variables.tf
+++ b/cwlogs-to-es/variables.tf
@@ -32,3 +32,7 @@ variable "aws_region" {
 variable "index_prefix" {
   default = "cwl"
 }
+
+variable "retention_in_days" {
+  default = 30
+}


### PR DESCRIPTION
manage the cw logs group with terraform and set a retention.

for https://github.com/skyscrapers/engineering/issues/35