### PR TITLE
Fix a bug where the sha keeps giving a diff

### DIFF
--- a/cwlogs-to-es/lambda.tf
+++ b/cwlogs-to-es/lambda.tf
@@ -19,7 +19,7 @@ resource "aws_lambda_function" "lambda" {
   description   = "Lambda function to ship AWS Cloudwatch logs to Elasticsearch for ${var.environment}"
 
   filename         = "${data.archive_file.zip.output_path}"
-  source_code_hash = "${data.archive_file.zip.output_sha}"
+  source_code_hash = "${data.archive_file.zip.output_base64sha256}"
 
   role    = "${aws_iam_role.iam_for_lambda.arn}"
   handler = "index.handler"


### PR DESCRIPTION
Aws expects the sha to be base64 encoded. Without the encoding
Terraform will always try to update the lambda function.