### PR TITLE
Improve logging and monitoring of the cwl-to-es

### DIFF
--- a/cwlogs-to-es/cw.tf
+++ b/cwlogs-to-es/cw.tf
@@ -10,3 +10,16 @@ resource "aws_cloudwatch_log_group" "lambda" {
 
   retention_in_days = "${var.retention_in_days}"
 }
+
+resource "aws_cloudwatch_log_metric_filter" "es_index_errors" {
+  name           = "ElasticSearchIndexErrors"
+  pattern        = "{ $.error EXISTS }"
+  log_group_name = "${aws_cloudwatch_log_group.lambda.name}"
+
+  metric_transformation {
+    name          = "ElasticSearchIndexErrors"
+    namespace     = "LogMetrics"
+    value         = "1"
+    default_value = "0"
+  }
+}


### PR DESCRIPTION

With this change, the cwl-to-es lambda function will log a single line per execution, with the result of that execution.

It will log in JSON format so it's easier to parse via a log metric filter.

I've also created a log metric filter to monitor the amount of errors thrown by the lambda function.

As per https://github.com/skyscrapers/engineering/issues/211